### PR TITLE
add the add fraction(s) command

### DIFF
--- a/src/main/java/org/jboss/forge/addon/swarm/facet/WildflySwarmFacet.java
+++ b/src/main/java/org/jboss/forge/addon/swarm/facet/WildflySwarmFacet.java
@@ -1,5 +1,7 @@
 package org.jboss.forge.addon.swarm.facet;
 
+import java.util.List;
+
 import org.jboss.forge.addon.projects.ProjectFacet;
 import org.jboss.forge.addon.swarm.config.WildflySwarmConfiguration;
 
@@ -14,4 +16,8 @@ public interface WildflySwarmFacet extends ProjectFacet
    WildflySwarmConfiguration getConfiguration();
 
    void setConfiguration(WildflySwarmConfiguration configuration);
+   
+   void installFractions(Iterable<String> selectedFractions);
+   
+   List<String> getFractionList();
 }

--- a/src/main/java/org/jboss/forge/addon/swarm/facet/impl/WildflySwarmFacetImpl.java
+++ b/src/main/java/org/jboss/forge/addon/swarm/facet/impl/WildflySwarmFacetImpl.java
@@ -1,11 +1,22 @@
 package org.jboss.forge.addon.swarm.facet.impl;
 
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Properties;
+import java.util.Scanner;
+
+import javax.inject.Inject;
 
 import org.apache.maven.model.Model;
 import org.jboss.forge.addon.dependencies.Coordinate;
+import org.jboss.forge.addon.dependencies.Dependency;
+import org.jboss.forge.addon.dependencies.DependencyException;
+import org.jboss.forge.addon.dependencies.DependencyResolver;
 import org.jboss.forge.addon.dependencies.builder.CoordinateBuilder;
 import org.jboss.forge.addon.dependencies.builder.DependencyBuilder;
+import org.jboss.forge.addon.dependencies.builder.DependencyQueryBuilder;
 import org.jboss.forge.addon.facets.AbstractFacet;
 import org.jboss.forge.addon.maven.plugins.ConfigurationBuilder;
 import org.jboss.forge.addon.maven.plugins.ConfigurationElementBuilder;
@@ -29,6 +40,8 @@ import org.jboss.forge.furnace.util.Strings;
 public class WildflySwarmFacetImpl extends AbstractFacet<Project>implements
          WildflySwarmFacet
 {
+   @Inject
+   private DependencyResolver dependencyResolver;
 
    private WildflySwarmConfiguration configuration;
 
@@ -126,4 +139,57 @@ public class WildflySwarmFacetImpl extends AbstractFacet<Project>implements
    {
       this.configuration = configuration;
    }
+   
+   @Override
+   public void installFractions(Iterable<String> selectedFractions)
+   {
+      Iterator<String> iterator = selectedFractions.iterator();
+      while (iterator.hasNext()) {
+         String[] parts = iterator.next().split(":");
+         Dependency dependency = DependencyBuilder.create(parts[0]).setArtifactId(parts[1])
+               .setVersion("${version.wildfly-swarm}");
+         DependencyFacet facet = getFaceted().getFacet(DependencyFacet.class);
+         facet.addDirectDependency(dependency);
+      }
+   }
+   
+   @Override
+   public List<String> getFractionList()
+   {
+      Dependency dependency = dependencyResolver.resolveArtifact(DependencyQueryBuilder.create(
+            CoordinateBuilder.create().setGroupId("org.wildfly.swarm").setArtifactId("wildfly-swarm-fraction-list")
+                  .setVersion("1.0.0.Alpha6-SNAPSHOT").setPackaging("txt")));
+
+      MavenFacet maven = getFaceted().getFacet(MavenFacet.class);
+      Model pom = maven.getModel();
+      Scanner s;
+      List<String> list = new ArrayList<String>();
+      try {
+         s = new Scanner(dependency.getArtifact().getUnderlyingResourceObject());
+         while (s.hasNextLine()) {
+            String currentFraction = s.nextLine();
+            if (!alreadyInstalled(currentFraction.split(":")[1], pom.getDependencies())) {
+               list.add(currentFraction);
+            }
+
+         }
+         s.close();
+      } catch (FileNotFoundException | DependencyException e) {
+         // TODO do some proper error handling
+         e.printStackTrace();
+      }
+      return list;
+   }
+
+   private boolean alreadyInstalled(String artifactId, List<org.apache.maven.model.Dependency> dependencies)
+   {
+      Iterator<org.apache.maven.model.Dependency> iterator = dependencies.iterator();
+      while (iterator.hasNext()) {
+         if (iterator.next().getArtifactId().equals(artifactId)) {
+            return true;
+         }
+      }
+      return false;
+   }
+
 }

--- a/src/main/java/org/jboss/forge/addon/swarm/facet/impl/WildflySwarmFacetImpl.java
+++ b/src/main/java/org/jboss/forge/addon/swarm/facet/impl/WildflySwarmFacetImpl.java
@@ -158,14 +158,12 @@ public class WildflySwarmFacetImpl extends AbstractFacet<Project>implements
    {
       Dependency dependency = dependencyResolver.resolveArtifact(DependencyQueryBuilder.create(
             CoordinateBuilder.create().setGroupId("org.wildfly.swarm").setArtifactId("wildfly-swarm-fraction-list")
-                  .setVersion("1.0.0.Alpha6-SNAPSHOT").setPackaging("txt")));
+                  .setVersion("1.0.0.Alpha6").setPackaging("txt")));
 
       MavenFacet maven = getFaceted().getFacet(MavenFacet.class);
       Model pom = maven.getModel();
-      Scanner s;
       List<String> list = new ArrayList<String>();
-      try {
-         s = new Scanner(dependency.getArtifact().getUnderlyingResourceObject());
+      try(Scanner s = new Scanner(dependency.getArtifact().getUnderlyingResourceObject())) {
          while (s.hasNextLine()) {
             String currentFraction = s.nextLine();
             if (!alreadyInstalled(currentFraction.split(":")[1], pom.getDependencies())) {
@@ -173,7 +171,6 @@ public class WildflySwarmFacetImpl extends AbstractFacet<Project>implements
             }
 
          }
-         s.close();
       } catch (FileNotFoundException | DependencyException e) {
          // TODO do some proper error handling
          e.printStackTrace();
@@ -183,9 +180,8 @@ public class WildflySwarmFacetImpl extends AbstractFacet<Project>implements
 
    private boolean alreadyInstalled(String artifactId, List<org.apache.maven.model.Dependency> dependencies)
    {
-      Iterator<org.apache.maven.model.Dependency> iterator = dependencies.iterator();
-      while (iterator.hasNext()) {
-         if (iterator.next().getArtifactId().equals(artifactId)) {
+      for (org.apache.maven.model.Dependency dep : dependencies){
+         if (dep.getArtifactId().equals(artifactId)) {
             return true;
          }
       }

--- a/src/main/java/org/jboss/forge/addon/swarm/ui/WildflySwarmAddFractionCommand.java
+++ b/src/main/java/org/jboss/forge/addon/swarm/ui/WildflySwarmAddFractionCommand.java
@@ -4,22 +4,27 @@ import javax.inject.Inject;
 
 import org.jboss.forge.addon.facets.FacetFactory;
 import org.jboss.forge.addon.facets.FacetNotFoundException;
+import org.jboss.forge.addon.facets.constraints.FacetConstraint;
 import org.jboss.forge.addon.projects.Project;
 import org.jboss.forge.addon.projects.ProjectFactory;
 import org.jboss.forge.addon.projects.ui.AbstractProjectCommand;
 import org.jboss.forge.addon.swarm.facet.WildflySwarmFacet;
+import org.jboss.forge.addon.ui.command.PrerequisiteCommandsProvider;
 import org.jboss.forge.addon.ui.context.UIBuilder;
 import org.jboss.forge.addon.ui.context.UIContext;
 import org.jboss.forge.addon.ui.context.UIExecutionContext;
 import org.jboss.forge.addon.ui.input.InputComponentFactory;
 import org.jboss.forge.addon.ui.input.UISelectMany;
 import org.jboss.forge.addon.ui.metadata.UICommandMetadata;
+import org.jboss.forge.addon.ui.result.NavigationResult;
 import org.jboss.forge.addon.ui.result.Result;
 import org.jboss.forge.addon.ui.result.Results;
+import org.jboss.forge.addon.ui.result.navigation.NavigationResultBuilder;
 import org.jboss.forge.addon.ui.util.Categories;
 import org.jboss.forge.addon.ui.util.Metadata;
 
-public class WildflySwarmAddFractionCommand extends AbstractProjectCommand {
+@FacetConstraint(WildflySwarmFacet.class)
+public class WildflySwarmAddFractionCommand extends AbstractProjectCommand implements PrerequisiteCommandsProvider {
 
    @Inject
    private FacetFactory facetFactory;
@@ -70,16 +75,22 @@ public class WildflySwarmAddFractionCommand extends AbstractProjectCommand {
 
    private WildflySwarmFacet getFacet(Project project)
    {
-      WildflySwarmFacet facet;
-      try {
-         facet = project.getFacet(WildflySwarmFacet.class);
-      } catch (FacetNotFoundException exception) {
-         facet = facetFactory.create(project, WildflySwarmFacet.class);
+      return project.getFacet(WildflySwarmFacet.class);
+   }
+   
+   @Override
+   public NavigationResult getPrerequisiteCommands(UIContext context)
+   {
+      NavigationResultBuilder builder = NavigationResultBuilder.create();
+      Project project = getSelectedProject(context);
+      if (project != null)
+      {
+         if (!project.hasFacet(WildflySwarmFacet.class))
+         {
+            builder.add(WildflySwarmSetupCommand.class);
+         }
       }
-      if (!facet.isInstalled()) {
-         facet.install();
-      }
-      return facet;
+      return builder.build();
    }
 
 }

--- a/src/main/java/org/jboss/forge/addon/swarm/ui/WildflySwarmAddFractionCommand.java
+++ b/src/main/java/org/jboss/forge/addon/swarm/ui/WildflySwarmAddFractionCommand.java
@@ -1,0 +1,85 @@
+package org.jboss.forge.addon.swarm.ui;
+
+import javax.inject.Inject;
+
+import org.jboss.forge.addon.facets.FacetFactory;
+import org.jboss.forge.addon.facets.FacetNotFoundException;
+import org.jboss.forge.addon.projects.Project;
+import org.jboss.forge.addon.projects.ProjectFactory;
+import org.jboss.forge.addon.projects.ui.AbstractProjectCommand;
+import org.jboss.forge.addon.swarm.facet.WildflySwarmFacet;
+import org.jboss.forge.addon.ui.context.UIBuilder;
+import org.jboss.forge.addon.ui.context.UIContext;
+import org.jboss.forge.addon.ui.context.UIExecutionContext;
+import org.jboss.forge.addon.ui.input.InputComponentFactory;
+import org.jboss.forge.addon.ui.input.UISelectMany;
+import org.jboss.forge.addon.ui.metadata.UICommandMetadata;
+import org.jboss.forge.addon.ui.result.Result;
+import org.jboss.forge.addon.ui.result.Results;
+import org.jboss.forge.addon.ui.util.Categories;
+import org.jboss.forge.addon.ui.util.Metadata;
+
+public class WildflySwarmAddFractionCommand extends AbstractProjectCommand {
+
+   @Inject
+   private FacetFactory facetFactory;
+
+   @Inject
+   private ProjectFactory projectFactory;
+
+   @Inject
+   private InputComponentFactory factory;
+
+   private UISelectMany<String> fractionElements;
+
+   @Override
+   public UICommandMetadata getMetadata(UIContext context)
+   {
+      return Metadata.forCommand(getClass()).name("Wildfly-Swarm: Add Fraction")
+            .category(Categories.create("Wildfly-Swarm")).description("Add one or more fractions. Installed fractions have been filtered out.");
+   }
+
+   @Override
+   public void initializeUI(UIBuilder builder) throws Exception
+   {
+      fractionElements = factory.createSelectMany("fractions", String.class).setLabel("Fraction List")
+            .setDescription("Fraction list");
+
+      fractionElements.setValueChoices(getFacet(getSelectedProject(builder)).getFractionList());
+      builder.add(fractionElements);
+   }
+
+   @Override
+   public Result execute(UIExecutionContext context) throws Exception
+   {
+      getFacet(getSelectedProject(context)).installFractions(fractionElements.getValue());
+      return Results.success("Command 'add fraction' successfully executed!");
+   }
+
+   @Override
+   protected ProjectFactory getProjectFactory()
+   {
+      return projectFactory;
+   }
+
+   @Override
+   protected boolean isProjectRequired()
+   {
+      return true;
+   }
+
+   private WildflySwarmFacet getFacet(Project project)
+   {
+      WildflySwarmFacet facet;
+      try {
+         facet = project.getFacet(WildflySwarmFacet.class);
+      } catch (FacetNotFoundException exception) {
+         facet = facetFactory.create(project, WildflySwarmFacet.class);
+      }
+      if (!facet.isInstalled()) {
+         facet.install();
+      }
+      return facet;
+   }
+
+}


### PR DESCRIPTION
This is the initial support for fractions. The list is retrieved from the `wildfly-swarm-fraction-list` artifact and it's possible to add several fractions in once. Already installed fractions are filtered out.

Next step, will be to manage dependencies between fractions, for instance, if -ejb is selected, -security will be filtered out (because it comes transitively). For this, the fraction list needs to supply this information. 

![fractions](https://cloud.githubusercontent.com/assets/335133/11004512/fdd45680-84b8-11e5-8ade-22234e5fa780.png)

I'm sure @gastaldi will have some interesting suggestion regarding my code ;) 